### PR TITLE
Add build-stack.

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -89,6 +89,11 @@
       packages:
         - title: build-nsl
           url: https://atom.io/packages/build-nsl
+    - title: Haskell
+      modal: haskell
+      packages:
+        - title: build-stack
+          url: https://atom.io/packages/build-stack
 - systems:
   title: Task Runner
   modal: runner


### PR DESCRIPTION
`build-stack` is a build provider for the `stack` build system for Haskell projects.