### PR TITLE
Add build-decaffeinate

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -31,6 +31,8 @@
           url: https://atom.io/packages/build-coffee
         - title: build-iced
           url: https://atom.io/packages/build-iced
+        - title: build-decaffeinate
+          url: https://atom.io/packages/build-decaffeinate
     - title: Rust
       modal: rs
       packages:


### PR DESCRIPTION
Should `build-coffee`, `build-iced` and `build-decaffeinate` be added into the JavaScript category as well? After all they all *build* JavaScript. 