### PR TITLE
Added atom-build-scons to task-runners

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -260,6 +260,11 @@
       packages:
         - title: build-ninja
           url: https://atom.io/packages/build-ninja
+    - title: SCons
+      modal: scons
+      packages:
+        - title: build-scons
+          url: https://atom.io/packages/build-scons
 - managers:
   title: Package Manager
   modal: manager


### PR DESCRIPTION
Hi,

here is a Atom builder for [SCons](http://scons.org/) projects. Provides common build targets for project folders which contain a `sconstruct` build file. Allows the definition of additional user targets by providing `targets.ini`alongside the the `sconstruct`file. Since the default language for SCons projects is C/C++ (via GCC), error matching for GCC is provided.

Regards,
Stefan