### PR TITLE
Added task runner for mbed-cli builds

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -277,6 +277,11 @@
       packages:
         - title: build-scons
           url: https://atom.io/packages/build-scons
+    - title: mbed
+      modal: mbed
+      packages:
+        - title: build-mbed
+          url: https://atom.io/packages/build-mbed
 - managers:
   title: Package Manager
   modal: manager


### PR DESCRIPTION
This builder provides integration of te ARMmbed command-line build system [mbed-cli](https://github.com/ARMmbed/mbed-cli). It defines targets for the most common options of the `mbed compile` subcommand.