### PR TITLE
Add build-elm-analyse

### DIFF
--- a/_data/providers.yml
+++ b/_data/providers.yml
@@ -223,6 +223,11 @@
       packages:
         - title: build-homebrew
           url: https://atom.io/packages/build-homebrew
+    - title: Elm
+      model: elm
+      packages:
+        - title: build-elm-analyse
+          url: https://atom.io/packages/build-elm-analyse
 - systems:
   title: Task Runner
   modal: runner


### PR DESCRIPTION
Hi!

I am maintaining [a small build provider](https://atom.io/packages/build-elm-analyse) which runs [elm-analyse](https://github.com/stil4m/elm-analyse) for [Elm](https://elm-lang.org) language.
Please consider adding an entry for it.

Thanks!